### PR TITLE
Removing the callback function

### DIFF
--- a/src/components/constructs/Layout/partials/Nav/Nav.js
+++ b/src/components/constructs/Layout/partials/Nav/Nav.js
@@ -27,8 +27,8 @@ const LayoutNav = ({ links, background, onButtonClick, isCollapsing }) => {
     SECONDARY_NAV_BREAKPOINT,
   ]);
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
-  const openMobileNav = useCallback(() => setIsMobileNavOpen(true));
-  const closeMobileNav = useCallback(() => setIsMobileNavOpen(false));
+  const openMobileNav = () => setIsMobileNavOpen(true);
+  const closeMobileNav = () => setIsMobileNavOpen(false);
   const { translateX } = useSpring({
     translateX: isMobileNavOpen ? 0 : 100,
     config: {


### PR DESCRIPTION
I understood that usually it is not recommended to use callback function as blanket perform optimization. 

The use of inline functions will not be detrimental impact on performance, so it is okay to use it in some cases. 

Therefore, I believe converging the callback "back" to inline function will solve this issue. 

Please, if not, let me know and we can discuss this issue further. 